### PR TITLE
Add `Courses` link to header across generated templates and existing pages

### DIFF
--- a/author/dharmeshm/index.html
+++ b/author/dharmeshm/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/aws-athena/advanced-sql-techniques-for-athena-users/index.html
+++ b/aws-athena/advanced-sql-techniques-for-athena-users/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Advanced SQL Techniques for AWS Athena Users</h1>
 <p>Welcome, Athena users! As you progress in your data analysis journey with Amazon Web Services (AWS) Athena, it's time to explore some advanced SQL techniques that will help streamline your workflow and unlock the full potential of this powerful tool. This article aims to provide you with an insightful guide on using advanced SQL functions, performance optimization tips, and best practices for working effectively with AWS Athena.</p>
 <h2>Mastering Advanced SQL Functions</h2>

--- a/aws-athena/faq-athena-and-s3-best-practices/index.html
+++ b/aws-athena/faq-athena-and-s3-best-practices/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>AWS Athena &amp; S3: Best Practices</h1>
 <p>Welcome to our guide on best practices for using Amazon Web Services (AWS) Athena and Amazon Simple Storage Service (S3). This article aims to provide you with valuable insights into optimizing your data querying experience.</p>
 <h2>What is AWS Athena?</h2>

--- a/aws-athena/faq-common-athena-use-cases-and-limitations/index.html
+++ b/aws-athena/faq-common-athena-use-cases-and-limitations/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Common AWS Athena Use Cases and Limitations</h1>
 <p>Amazon Web Services (AWS) Athena is a powerful, serverless data query service that makes it easy to analyze data in Amazon S3 using SQL. In this article, we will explore some common use cases for AWS Athena as well as its limitations.</p>
 <h2>Common Use Cases</h2>

--- a/aws-athena/handling-schema-changes-in-athena-tables/index.html
+++ b/aws-athena/handling-schema-changes-in-athena-tables/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding Schema Changes in Amazon Athena</h1>
 <p>In the dynamic world of data warehousing, schema changes are an inevitable part of the process. This article focuses on how to handle schema changes effectively in Amazon Athena, a serverless, interactive query service that makes it easy to analyze data in various data sources.</p>
 <h2>Importance of Handling Schema Changes</h2>

--- a/aws-athena/integrating-aws-athena-with-other-aws-services/index.html
+++ b/aws-athena/integrating-aws-athena-with-other-aws-services/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Integrating AWS Athena with Other AWS Services</h1>
 <p>Welcome to our guide on integrating Amazon Web Services (AWS) Athena with other AWS services! In this article, we will explore how to leverage the power of AWS Athena in conjunction with various AWS offerings to streamline your data analysis and processing workflows.</p>
 <h2>What is AWS Athena?</h2>

--- a/aws-athena/optimizing-athena-query-performance/index.html
+++ b/aws-athena/optimizing-athena-query-performance/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Optimizing AWS Athena Query Performance</h1>
 <p>Amazon Web Services (AWS) Athena is a powerful tool for analyzing data stored in Amazon S3. However, to make the most of it, you need to optimize your queries for performance. In this article, we will discuss some best practices and techniques to improve the efficiency of your Athena queries.</p>
 <h2>Choose the Right Storage Class</h2>

--- a/aws-athena/querying-unstructured-data-json-and-logs/index.html
+++ b/aws-athena/querying-unstructured-data-json-and-logs/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Querying Unstructured Data in JSON and Logs using AWS Athena</h1>
 <p>Welcome to this comprehensive guide on leveraging Amazon Web Services (AWS) Athena to query unstructured data, specifically JSON and logs. In today's data-driven world, the ability to process and analyze vast amounts of unstructured data is essential for businesses seeking insights to drive decision-making processes.</p>
 <h2>What is AWS Athena?</h2>

--- a/aws-athena/resolving-connectivity-issues-with-data-sources/index.html
+++ b/aws-athena/resolving-connectivity-issues-with-data-sources/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Resolving Connectivity Issues with Data Sources in AWS Athena</h1>
 <p>Amazon Web Services (AWS) Athena is a powerful, serverless data query service that makes it easy to analyze data directly from Amazon S3 using SQL. However, connectivity issues may occur at times, causing delays or preventing access to your data sources. This article will guide you through the steps to resolve common AWS Athena connectivity problems.</p>
 <h2>Check Data Source Availability</h2>

--- a/aws-athena/securing-your-aws-athena-environment/index.html
+++ b/aws-athena/securing-your-aws-athena-environment/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <article>
 <h1>Securing Your AWS Athena Environment</h1>
 <p>Welcome to our comprehensive guide on securing your Amazon Web Services (AWS) Athena environment. This article aims to provide you with the essential steps and best practices to ensure the security of your data and your Athena workspace.</p>

--- a/aws-athena/troubleshooting- Glue-data-catalog-integration/index.html
+++ b/aws-athena/troubleshooting- Glue-data-catalog-integration/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Troubleshooting AWS Athena Integration with Glue Data Catalog</h1>
 <p>Welcome to our guide on troubleshooting AWS Athena integration with Glue Data Catalog. In this article, we will walk you through common issues and provide solutions for seamless data querying using these powerful Amazon Web Services.</p>
 <h2>Prerequisites</h2>

--- a/aws-athena/troubleshooting-common-query-errors/index.html
+++ b/aws-athena/troubleshooting-common-query-errors/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Troubleshooting Common Query Errors in AWS Athena</h1>
 <p>Amazon Web Services (AWS) Athena is a powerful tool for querying data stored in various data sources like Amazon S3. However, it's not uncommon to encounter errors when running queries, especially for new users. This article aims to guide you through some of the most common query errors and their solutions.</p>
 <h2>1. Syntax Errors</h2>

--- a/aws-athena/troubleshooting-performance-issues-with-large-datasets/index.html
+++ b/aws-athena/troubleshooting-performance-issues-with-large-datasets/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Troubleshooting Performance Issues with Large Datasets in AWS Athena</h1>
 <p>Welcome to our guide on troubleshooting performance issues when working with large datasets in Amazon Web Services (AWS) Athena. This article aims to provide you with valuable insights and practical solutions to optimize your experience.</p>
 <h2>Understanding Performance Issues</h2>

--- a/aws-athena/understanding-athena-cost-management-techniques/index.html
+++ b/aws-athena/understanding-athena-cost-management-techniques/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding AWS Athena Cost Management Techniques</h1>
 <p>Welcome to our comprehensive guide on managing costs with Amazon Web Services (AWS) Athena! This article aims to provide you with an in-depth understanding of techniques that can help optimize your usage of Athena, ensuring a cost-effective data analysis experience.</p>
 <h2>What is AWS Athena?</h2>

--- a/aws-athena/using-ctas-and-views-effectively-in-athena/index.html
+++ b/aws-athena/using-ctas-and-views-effectively-in-athena/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Effectively Using CTA's and Views in Amazon Athena</h1>
 <p>Amazon Athena, a serverless, interactive query service provided by AWS, allows you to analyze data directly using SQL. One of the powerful features that make Athena versatile is its ability to utilize Common Table Expressions (CTEs) and Views for better organization and management of your data. This article will guide you through the effective use of CTE's and Views in Amazon Athena.</p>
 <h2>Common Table Expressions (CTEs)</h2>

--- a/aws-athena/working-with-partitioned-data-best-practices/index.html
+++ b/aws-athena/working-with-partitioned-data-best-practices/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Working with Partitioned Data in AWS Athena: Best Practices</h1>
 <p>Welcome to our guide on effectively working with partitioned data using Amazon Web Services (AWS) Athena. This article aims to provide you with best practices that will optimize your experience and help you get the most out of AWS Athena.</p>
 <h2>Understanding Partitioned Data</h2>

--- a/aws/design-efficient-datalakes/index.html
+++ b/aws/design-efficient-datalakes/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/aws/some-use-cases-for-using-aws-glue/index.html
+++ b/aws/some-use-cases-for-using-aws-glue/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Some Use Cases for Using AWS Glue</h1>
 <p>AWS Glue, a serverless data integration service, simplifies the process of discovering, preparing, and combining data for analytics, machine learning, and application development. With AWS Glue, you can start analyzing your data in minutes instead of months.</p>
 <h2 id="s2">Components of AWS Glue</h2>

--- a/category/data-warehousing/index.html
+++ b/category/data-warehousing/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Data Warehousing: The Power to Unlock Business Insights</h1>
 <p>Data warehousing is a critical component in the process of extracting valuable insights from your organization's data, enabling businesses to make informed decisions and drive growth. In this article, we'll delve into what data warehousing is, its importance, and how it can benefit your organization.</p>
 <h2>What is Data Warehousing?</h2>

--- a/category/learn/full-course/index.html
+++ b/category/learn/full-course/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <section id="welcome">
 <h1>Welcome to Our Full Course on Category/Learn</h1>
 <p>Embark on an exciting journey of learning! This full course is designed to provide you with a comprehensive understanding of the 'Category/Learn' topic. Let's dive in and explore together.</p>

--- a/category/learn/page/28/index.html
+++ b/category/learn/page/28/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/category/linux/page/2/index.html
+++ b/category/linux/page/2/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/courses/index.html
+++ b/courses/index.html
@@ -12,7 +12,7 @@
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-        <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+        <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
       </ul>
     </nav>
   </header>

--- a/data-warehousing/active-vs-passive-stages/index.html
+++ b/data-warehousing/active-vs-passive-stages/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Active vs Passive Stages in Data Warehousing</h1>
 <p>Data warehousing is a strategic business process that consolidates and stores an organization's data from various sources for reporting, analysis, and decision-making purposes. This article aims to explain the two primary stages of data warehousing: Active and Passive.</p>
 <h2>Active Stage</h2>

--- a/data-warehousing/aggregator-stage-in-datastage/index.html
+++ b/data-warehousing/aggregator-stage-in-datastage/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding the Aggregator Stage in DataStage</h1>
 <p>In data warehousing, data aggregation is a crucial step in preparing data for analysis and reporting. In this article, we'll dive into the Aggregator stage in IBM InfoSphere DataStage, exploring its features, benefits, and use cases.</p>
 <h2>What is the Aggregator Stage?</h2>

--- a/data-warehousing/change-capture-stage-in-datastage/index.html
+++ b/data-warehousing/change-capture-stage-in-datastage/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Change Capture Stage in DataStage - Data Warehousing</h1>
 <section>
 <h2>Change Capture Stage</h2>

--- a/data-warehousing/combine-data-using-the-funnel-stage/index.html
+++ b/data-warehousing/combine-data-using-the-funnel-stage/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/data-warehousing/create-jobs/index.html
+++ b/data-warehousing/create-jobs/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Creating Jobs in Data Warehousing</h1>
 <p>Estimated Reading Time: 2 minutes</p>
 <p>DataStage offers the following types of jobs:</p>

--- a/data-warehousing/data-partitioning-and-collecting-in-datastage/index.html
+++ b/data-warehousing/data-partitioning-and-collecting-in-datastage/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Data Partitioning and Collecting in Datastage</h1>
 <h2>Introduction</h2>
 <p>Data partitioning is an indispensable technique for enhancing the performance of ETL (Extract, Transform, Load) jobs in big data processing. This article aims to provide a comprehensive guide on implementing data partitioning and collection in IBM InfoSphere DataStage.</p>

--- a/data-warehousing/data-transformations/index.html
+++ b/data-warehousing/data-transformations/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/data-warehousing/datastage-active-vs-passive-stage/index.html
+++ b/data-warehousing/datastage-active-vs-passive-stage/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding Active vs. Passive Stages in DataStage for Data Warehousing</h1>
 <p>In the realm of Data Warehousing, the terms 'Active Stage' and 'Passive Stage' are fundamental concepts to grasp when working with DataStage.</p>
 <h2>Active Stage vs Passive Stage</h2>

--- a/data-warehousing/datastage-cff-stage/index.html
+++ b/data-warehousing/datastage-cff-stage/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <article>
 <h1>Understanding the CFF Stage in DataStage</h1>
 <p>The CFF stage, short for Complex Flat File stage, is a crucial component in the DataStage environment within Data Warehousing.</p>

--- a/data-warehousing/datastage-configuration-file/index.html
+++ b/data-warehousing/datastage-configuration-file/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>DataStage Configuration File: A Comprehensive Guide to Data Warehousing</h1>
 <p>Reading Time: 4 minutes</p>
 <p>The DataStage configuration file serves as the master control file, residing on the server side, for jobs. This atext file describes the parallel system resources and architecture, ensuring that DataStage understands the system's hardware configuration. The configuration file supports architectures such as SMP (Single machine with multiple CPUs, shared memory, and disk), Grid, Cluster, or MPP (multiple CPUs, multiple nodes, and dedicated memory per node).</p>

--- a/data-warehousing/datastage-file-stages/index.html
+++ b/data-warehousing/datastage-file-stages/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>DataStage File Stages: A Comprehensive Guide</h1>
 <p>*DataStage*, an ETL (Extract, Transform, Load) tool developed by IBM, is a powerful platform for data integration tasks. One of the key components in DataStage are the **File Stages**. This article aims to provide a comprehensive understanding of File Stages in DataStage.</p>
 <h2>Understanding File Stages</h2>

--- a/data-warehousing/datastage-important-terms/index.html
+++ b/data-warehousing/datastage-important-terms/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/data-warehousing/datastage-jobs-sequences-and-containers/index.html
+++ b/data-warehousing/datastage-jobs-sequences-and-containers/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding Datastage Jobs, Sequences, and Containers in Data Warehousing</h1>
 <p><strong>Reading Time:</strong> &lt; 1 minute</p>
 <h2>Parallel jobs:</h2>

--- a/data-warehousing/datastage-osh-script/index.html
+++ b/data-warehousing/datastage-osh-script/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>DataStage OSH Scripting: A Comprehensive Guide</h1>
 <h2 id="intro">Introduction to DataStage OSH Scripting</h2>
 <p>The DataStage Onshore Script (OSH) is a powerful tool that extends DataStage's capabilities by allowing users to write custom functions in Java or JavaScript. This feature can be used to perform complex transformations, calculations, and integrations not available with standard DataStage operators.</p>

--- a/data-warehousing/datastage-overview/index.html
+++ b/data-warehousing/datastage-overview/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>DataStage Overview - Data Warehousing</h1>
 <p>DataStage is an ETL (Extract, Transform, Load) tool that forms part of the IBM InfoSphere. Widely used for the development and maintenance of Data Warehouses and Data Marts, this tool can extract data from various sources, perform transformations based on business requirements, and load the processed data into selected data warehouses. Originally launched by VMark in the mid-90s, it was later acquired by IBM in 2005 and renamed to IBM WebSphere DataStage, and subsequently to IBM InfoSphere.</p>
 <p>In the realm of Business Intelligence (BI), DataStage plays a significant role in managing information. It provides a Graphical User Interface (GUI) for carrying out the ETL work. The ETL work is executed through jobs, which are individual units of implementable work that describe the data flow between various stages.</p>

--- a/data-warehousing/datastage-parallel-processing-2/index.html
+++ b/data-warehousing/datastage-parallel-processing-2/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>DataStage Parallel Processing - Data Warehousing</h1>
 <p>This article explores the concept of parallel processing in DataStage, a powerful tool for data warehousing. The parallel job structure is explained with a simple representation of a data source, Transformer stage, and target. The job is optimized through advanced properties using pipeline and partitioning methods at runtime.</p>
 <h2>Pipeline Parallelism</h2>

--- a/data-warehousing/datastage-parallel-processing/index.html
+++ b/data-warehousing/datastage-parallel-processing/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding Parallel Processing in DataStage - A Key Concept in Data Warehousing</h1>
 <p>Parallel processing, or Parallelism, refers to the simultaneous use of multiple CPUs or processor cores to execute a program or computational threads. This technique makes programs run faster as it leverages multiple engines (CPUs or Cores). In DataStage, parallel processing is supported through two types: Pipeline Parallelism and Partition Parallelism.</p>
 <h2>Pipeline Parallelism</h2>

--- a/data-warehousing/datastage-triggers/index.html
+++ b/data-warehousing/datastage-triggers/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Data Warehousing and DataStage Triggers: A Comprehensive Guide</h1>
 <p>Data warehousing has become a crucial aspect of modern businesses, allowing organizations to store, integrate, and analyze large amounts of data from various sources. In this article, we will delve into the world of data warehousing and explore the concept of triggers in DataStage, a popular ETL (Extract, Transform, Load) tool.</p>
 <h2>What is Data Warehousing?</h2>

--- a/data-warehousing/date-functions-in-datastage/index.html
+++ b/data-warehousing/date-functions-in-datastage/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 
 <h2>DataStage and Date Functions</h2>
 

--- a/data-warehousing/design-a-data-model-example/index.html
+++ b/data-warehousing/design-a-data-model-example/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Design a Data Model Example - Data Warehousing</h1>
 <p>Estimated Reading Time: &lt; 5 minutes</p>
 <h2>Problem Statement</h2>

--- a/data-warehousing/different-stages/index.html
+++ b/data-warehousing/different-stages/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Data Warehousing: Different Stages</h1>
 <p id="UsingDatabaseandFileStages">DataStage offers three main types of stages: File and Database Stages, Dynamic Relational Stages, and Processing Stages. Each stage features a set of predefined and editable properties.</p>
 <h2>Server Job Database Stages</h2>

--- a/data-warehousing/etl-tools-in-markets/index.html
+++ b/data-warehousing/etl-tools-in-markets/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>ETL Tools in Markets - Data Warehousing</h1>
 <p>While programmers can set up ETL (Extract, Transform, Load) processes using various programming languages, creating these processes from scratch can become complex. To streamline the process, companies are increasingly adopting ETL tools. By utilizing an established ETL framework, one may enhance connectivity and scalability chances.</p>
 <p>An ideal ETL tool should effectively communicate with numerous relational databases and read various file formats used within an organization. Over time, ETL tools have evolved to encompass Enterprise Application Integration or even Enterprise Service Bus systems, extending beyond just data extraction, transformation, and loading.</p>

--- a/data-warehousing/etl-vs-elt-must-know-differences/images/1/022218_0954_ETLvsELTMus1.html
+++ b/data-warehousing/etl-vs-elt-must-know-differences/images/1/022218_0954_ETLvsELTMus1.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/data-warehousing/etl-vs-elt-must-know-differences/images/1/022218_0954_ETLvsELTMus2.html
+++ b/data-warehousing/etl-vs-elt-must-know-differences/images/1/022218_0954_ETLvsELTMus2.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/data-warehousing/etl-vs-elt-must-know-differences/index.html
+++ b/data-warehousing/etl-vs-elt-must-know-differences/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 
     <h1>Data Warehousing: ETL vs ELT - Must Know Differences</h1>
     <h2>Introduction</h2>

--- a/data-warehousing/excel-data-in-datastage-unstructured-datastage/index.html
+++ b/data-warehousing/excel-data-in-datastage-unstructured-datastage/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 
 <div>
 <h1>What is Unstructured Data?</h1>

--- a/data-warehousing/how-to-check-netezza-versions-history/index.html
+++ b/data-warehousing/how-to-check-netezza-versions-history/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>How to Check the History of Netezza Versions?</h1>
 <p>To find the history of NPS upgrades on your server, run the following command:</p>
 <pre>$more /nz/.versions/versionhistory</pre>

--- a/data-warehousing/how-to-find-netezza-model-type/index.html
+++ b/data-warehousing/how-to-find-netezza-model-type/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
   <article>
       <h1>How to Find Netezza Model Type in Data Warehousing</h1>
       <p>Understanding the model type of your Netezza system is crucial for performance tuning, system upgrades, and capacity planning. This article explains how to identify the model type of a Netezza appliance using SQL queries and system tables.</p>

--- a/data-warehousing/interview-questions/index.html
+++ b/data-warehousing/interview-questions/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <footer>
 <h3>Meet Ananth Tirumanur. Hi there 👋</h3>
 <h4>I work on projects in data science, big data, data engineering, data modeling, software engineering, and system design.</h4>

--- a/data-warehousing/introduction-to-datastage-director/index.html
+++ b/data-warehousing/introduction-to-datastage-director/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Introduction to DataStage Director - Data Warehousing</h1>
 <p>In the DataStage Director, we can:</p>
 <ul>

--- a/data-warehousing/join-stage-in-datastage/index.html
+++ b/data-warehousing/join-stage-in-datastage/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Join Stage in DataStage - Understanding Join Operations in Data Warehousing</h1>
 <p>The Join stage is a crucial processing component in DataStage, performing join operations on multiple input data sets and outputting the resulting data set.</p>
 <p>The Join stage is one of three stages that execute table joins based on key column values. These stages differ primarily in their memory usage, treatment of rows with unmatched keys, and requirements for input data.</p>

--- a/data-warehousing/join-vs-merge-vs-lookup-datastage/index.html
+++ b/data-warehousing/join-vs-merge-vs-lookup-datastage/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>DataStage: Join vs Merge vs Lookup</h1>
 <p>In DataStage, data integration and transformation tasks can be performed using various operations such as Join, Merge, and Lookup. These three operations are commonly used for combining data from multiple sources, but they function differently and have specific use cases. Let's explore each operation in detail.</p>
 <h2>Join</h2>

--- a/data-warehousing/lookup-stage-in-datastage/index.html
+++ b/data-warehousing/lookup-stage-in-datastage/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Lookup Stage in DataStage - Data Warehousing</h1>
 <section>
 <h2>Overview</h2>

--- a/data-warehousing/merge-stage-in-datastage/index.html
+++ b/data-warehousing/merge-stage-in-datastage/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Merge Stage in DataStage - Data Warehousing</h1>
 <p>The Merge stage is a processing stage that can have any number of input links, a single output link, and the same number of reject links as there are update input links. This stage is one of three stages used for joining tables based on key columns.</p>
 <p>The Merge stage combines a master dataset with one or more update datasets based on the key columns. The output record contains all the columns from the master record plus any additional columns from each update record that are required. A master record and update record will be merged only if both have the same key column values.</p>

--- a/data-warehousing/null-handling-functions-in-datastage/index.html
+++ b/data-warehousing/null-handling-functions-in-datastage/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/data-warehousing/number-functions-in-datastage/index.html
+++ b/data-warehousing/number-functions-in-datastage/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>DataStage Number Functions</h1>
 <h2>Introduction</h2>
 <p>In this guide, we will explore the various number functions available in DataStage and learn how to use them effectively.</p>

--- a/data-warehousing/olap-terms-and-definitions/index.html
+++ b/data-warehousing/olap-terms-and-definitions/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/data-warehousing/oltp-vs-olap-whats-the-difference/index.html
+++ b/data-warehousing/oltp-vs-olap-whats-the-difference/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 
 
  <h2>OLTP vs OLAP: Understanding the Differences</h2>

--- a/data-warehousing/overview-of-aws-glue/index.html
+++ b/data-warehousing/overview-of-aws-glue/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <footer>
 <h3>Meet Ananth Tirumanur. Hi there 👋</h3>
 <h4>I work on projects in data science, big data, data engineering, data modeling, software engineering, and system design.</h4>

--- a/data-warehousing/remove-duplicates-stage-in-datastage/index.html
+++ b/data-warehousing/remove-duplicates-stage-in-datastage/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Remove Duplicates Stage in DataStage - A Comprehensive Guide</h1>
 <p>The Remove Duplicates stage is a crucial processing stage in Data Warehousing, particularly when dealing with large datasets. This stage can have a single input link and a single output link, processing a single sorted dataset as input, eliminating duplicate rows, and writing the results to an output dataset.</p>
 <p>For optimal performance, it's recommended that the input data is already sorted for this stage, ensuring that all records with similar key values are adjacent. In case sorting is not done prior, a 'Link Level Sort' can be performed instead of adding a separate ‘Sort stage’.</p>

--- a/data-warehousing/runtime-column-propagation-in-datastage/index.html
+++ b/data-warehousing/runtime-column-propagation-in-datastage/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Runtime Column Propagation in DataStage - Data Warehousing</h1>
 <p>InfoSphere DataStage offers flexibility when it comes to handling metadata. It can manage situations where the metadata is not fully defined.</p>
 <p>When data is sent from source to target, sometimes only required columns are needed. You can define a portion of your schema and specify that if your job encounters additional columns during runtime that are not defined in the metadata, it will adopt these extra columns and propagate them throughout the job. This process is called Runtime Column Propagation (RCP).</p>

--- a/data-warehousing/slowly-changing-dimensions/index.html
+++ b/data-warehousing/slowly-changing-dimensions/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 
 
     **Understanding Slowly Changing Dimensions (SCD) in Data Warehousing**

--- a/data-warehousing/snowflake-interview-questions/index.html
+++ b/data-warehousing/snowflake-interview-questions/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Preparing for a Snowflake Interview: Common Questions and Answers</h1>
 <h2 id="understanding-snowflake">Understanding Snowflake</h2>
 <p>Snowflake is a cloud-based data warehousing platform that offers flexible, scalable, and secure solutions for data storage, processing, and analytics. It allows users to store structured and semi-structured data, perform complex queries, and integrate with various business intelligence tools.</p>

--- a/data-warehousing/sort-data-using-in-stage-sorts-and-sort-stage/index.html
+++ b/data-warehousing/sort-data-using-in-stage-sorts-and-sort-stage/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Sorting Data in Data Warehousing: In-Stage Sorts and Sort Stage</h1>
 <p>During various processing stages, you can either select or set the sort criteria, often indicated by a small "Sort" icon within the metadata link. This is known as an in-stage sort.</p>
 <p>You might wonder then, why there's a separate Sort stage available and when it would be necessary to use it? The answer lies in the control over memory allocation and sorting methodology.</p>

--- a/data-warehousing/surrogate-key-generator-stage-in-datastage/index.html
+++ b/data-warehousing/surrogate-key-generator-stage-in-datastage/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Surrogate Key Generator Stage in DataStage: A Comprehensive Guide</h1>
 <section id="introduction">
 <h2>Introduction</h2>

--- a/data-warehousing/table-definition-and-schemas/index.html
+++ b/data-warehousing/table-definition-and-schemas/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding Table Definitions and Schemas in Data Warehousing</h1>
 <p>When working with data, it's crucial to define the data you are handling. This definition is achieved by importing or creating table definitions, which can be used in your job designs.</p>
 <p>Table definitions serve as the foundation for your DataStage project, specifying the data to be utilized at each stage of a job. These definitions are stored in the repository and are shared among all projects. A minimum of table definitions should be available for each data source and one for each data target in the data warehouse.</p>

--- a/data-warehousing/traditional-etl-vs-aws-glue/index.html
+++ b/data-warehousing/traditional-etl-vs-aws-glue/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Traditional ETL vs AWS Glue - Data Warehousing</h1>
 <p>ETL stands for Extraction, Transformation, and Load, and we will discuss these topics:</p>
 <ol>

--- a/data-warehousing/type-conversion-function-in-datastage/index.html
+++ b/data-warehousing/type-conversion-function-in-datastage/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Type Conversion Functions in DataStage - Data Warehousing</h1>
 <h2>Character Generation and Conversion</h2>
 <ul>

--- a/data-warehousing/what-is-a-olap-cube/index.html
+++ b/data-warehousing/what-is-a-olap-cube/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>What is a OLAP Cube?</h1>
 <p>A data warehouse OLAP (Online Analytical Processing) cube is a multidimensional representation of data, designed to support business intelligence and data analysis. It's a powerful tool for analyzing data from multiple angles, providing insights and answers to complex questions.</p>
 <h2>Basic Analytical Operations of OLAP</h2>

--- a/data-warehousing/what-is-dimensional-model-in-data-warehouse/index.html
+++ b/data-warehousing/what-is-dimensional-model-in-data-warehouse/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding Dimensional Model in Data Warehouse</h1>
 <p>In the realm of data warehousing, a Dimensional Model is a fundamental structure that helps organize and analyze large volumes of data from operational systems in a way that's efficient for business intelligence (BI) reporting and analysis. This model is crucial for understanding patterns, trends, and other insights hidden within your data.</p>
 <h2>Components of a Dimensional Model</h2>

--- a/data-warehousing/what-is-molap-architecture-advantages-example-tools/index.html
+++ b/data-warehousing/what-is-molap-architecture-advantages-example-tools/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding MOLAP Architecture: Advantages, Examples, and Tools</h1>
 <h2>What is MOLAP?</h2>
 <p>Multidimensional Online Analytical Processing (MOLAP) is a method for storing and analyzing data in a multidimensional cube structure. It offers high performance for complex analytic queries through its use of pre-computed aggregates, making it ideal for operational business intelligence (BI) reporting needs.</p>

--- a/databricks/common-errors-in-databricks-sql-and-how-to-solve-them/index.html
+++ b/databricks/common-errors-in-databricks-sql-and-how-to-solve-them/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Common Errors in Databricks SQL and How to Solve Them</h1>
 <p>Welcome to our guide on the common errors encountered when working with Databbricks SQL and their solutions. This article is designed to help you navigate through these challenges, ensuring a smooth experience as you leverage the power of Databricks for your data processing needs.</p>
 <h2>1. Connection Errors</h2>

--- a/databricks/debugging-databricks-pipelines-and-workflows/index.html
+++ b/databricks/debugging-databricks-pipelines-and-workflows/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Debugging Databricks Pipelines and Workflows</h1>
 <p>Welcome to our comprehensive guide on debugging Databricks pipelines and workflows! In this article, we will walk you through the process of identifying and resolving common issues that may arise while working with these powerful tools.</p>
 <h2>Understanding the Basics</h2>

--- a/databricks/faq-databricks-delta-live-tables/index.html
+++ b/databricks/faq-databricks-delta-live-tables/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Frequently Asked Questions about Databricks Delta Live Tables</h1>
 <section id="what-are-databricks-delta-live-tables">
 <h2>What are Databricks Delta Live Tables?</h2>

--- a/databricks/faq-databricks-security-best-practices/index.html
+++ b/databricks/faq-databricks-security-best-practices/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>FAQ: Databricks Security Best Practices</h1>
 <section id="faq-databricks-security">
 <h2>Q1. What are some best practices for securing my Databricks workspace?</h2>

--- a/databricks/handling-databricks-notebook-conflicts/index.html
+++ b/databricks/handling-databricks-notebook-conflicts/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Handling Databricks Notebook Conflicts</h1>
 <p>Welcome to our guide on managing conflicts in Databricks Notebooks! This article aims to provide you with a comprehensive understanding of how to effectively deal with conflicts that may arise while working collaboratively in Databricks.</p>
 <h2>Understanding Conflicts</h2>

--- a/databricks/handling-large-datasets-and-memory-issues-in-databricks/index.html
+++ b/databricks/handling-large-datasets-and-memory-issues-in-databricks/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Handling Large Datasets and Memory Issues in Databricks</h1>
 <p>Welcome to our comprehensive guide on handling large datasets and memory issues in Databricks! This article is designed to provide you with valuable insights and practical solutions to optimize your data processing workflows.</p>
 <h2>Understanding the Challenge</h2>

--- a/databricks/managing-databricks-permissions-and-access-control/index.html
+++ b/databricks/managing-databricks-permissions-and-access-control/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <article>
 <h1>Managing Databricks Permissions and Access Control</h1>
 <p>Welcome to our guide on managing Databricks permissions and access control! This article aims to provide you with a comprehensive understanding of how to effectively manage user roles, group policies, and data access in the Databricks environment.</p>

--- a/databricks/optimizing-databricks-job-performance/index.html
+++ b/databricks/optimizing-databricks-job-performance/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Optimizing Databricks Job Performance</h1>
 <p>Welcome to our guide on optimizing Databricks job performance! In this article, we will discuss various strategies and best practices to help you maximize the efficiency of your Databricks jobs. Whether you're a seasoned user or just starting out, these tips will help you get the most out of your Databricks experience.</p>
 <h2>Understanding Your Databricks Cluster</h2>

--- a/databricks/resolving-common-databricks-cluster-issues/index.html
+++ b/databricks/resolving-common-databricks-cluster-issues/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Resolving Common Databricks Cluster Issues</h1>
 <p>Welcome to our comprehensive guide on resolving common Databricks cluster issues! This article aims to help you effectively troubleshoot and maintain your Databriks clusters, ensuring smooth and efficient data processing.</p>
 <h2>Understanding Cluster Issues in Databricks</h2>

--- a/databricks/troubleshooting-databricks-connect-issues/index.html
+++ b/databricks/troubleshooting-databricks-connect-issues/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Troubleshooting Databricks Connect Issues</h1>
 <p>Welcome to our guide on troubleshooting connectivity issues in Databricks. This article aims to help you identify and resolve common connection problems that may arise while working with the Databricks platform.</p>
 <h2>Check Your Connection Settings</h2>

--- a/databricks/troubleshooting-mlflow-integration-in-databricks/index.html
+++ b/databricks/troubleshooting-mlflow-integration-in-databricks/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Troubleshooting MLflow Integration in Databricks</h1>
 <p>Welcome to our comprehensive guide on troubleshooting MLflow integration within the Databricks environment. This article aims to provide you with a step-by-step approach to resolving common issues and errors encountered during the process.</p>
 <h2>Prerequisites</h2>

--- a/databricks/troubleshooting-spark-ui-for-performance/index.html
+++ b/databricks/troubleshooting-spark-ui-for-performance/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Troubleshooting Spark UI for Performance in Databricks</h1>
 <p>Welcome to our guide on troubleshooting the Spark UI for performance in Databricks! This article aims to provide you with essential tips and best practices to optimize your Spark applications and ensure optimal performance.</p>
 <h2>Understanding the Spark UI</h2>

--- a/databricks/understanding-and-fixing-delta-lake-problems/index.html
+++ b/databricks/understanding-and-fixing-delta-lake-problems/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding and Fixing Delta Lake Problems</h1>
 <p>Welcome to our comprehensive guide on understanding and fixing common issues encountered in Apache Delta Lake! This article is designed to provide you with a deep dive into the inner workings of Delta Lake, as well as practical solutions to resolve potential problems.</p>
 <h2>What is Delta Lake?</h2>

--- a/databricks/understanding-databricks-cost-management/index.html
+++ b/databricks/understanding-databricks-cost-management/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding Databricks Cost Management</h1>
 <p>Welcome to our comprehensive guide on understanding Databricks cost management! This article aims to provide you with a clear and concise overview of how Databricks handles costs and offers strategies for effective cost optimization.</p>
 <h2>What is Databricks?</h2>

--- a/databricks/working-with-databricks-git-integration-troubleshooting/index.html
+++ b/databricks/working-with-databricks-git-integration-troubleshooting/index.html
@@ -12,7 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" style="display:none;visibility:hidden" width="0"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Working with Databricks Git Integration: Troubleshooting</h1>
 <p>Welcome to our guide on troubleshooting issues related to Databricks Git Integration! This article aims to help you navigate common challenges and provide solutions for a seamless integration experience.</p>
 <h2>Prerequisites</h2>

--- a/free-courses/index.html
+++ b/free-courses/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/free-utilities/aws-cloudformation-validator/index.html
+++ b/free-utilities/aws-cloudformation-validator/index.html
@@ -24,7 +24,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <nav>
         <ul>
             <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-            <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+            <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
         </ul>
     </nav>
 </header>

--- a/free-utilities/base64-encoder-decoder/index.html
+++ b/free-utilities/base64-encoder-decoder/index.html
@@ -22,7 +22,7 @@
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-        <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+        <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
       </ul>
     </nav>
   </header>

--- a/free-utilities/college-fit/index.html
+++ b/free-utilities/college-fit/index.html
@@ -49,7 +49,7 @@
     <nav>
         <ul>
             <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-            <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+            <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
         </ul>
     </nav>
 </header>

--- a/free-utilities/combine-pdf/index.html
+++ b/free-utilities/combine-pdf/index.html
@@ -38,7 +38,7 @@
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-        <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+        <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
       </ul>
     </nav>
   </header>

--- a/free-utilities/convert-html-to-md/index.html
+++ b/free-utilities/convert-html-to-md/index.html
@@ -62,7 +62,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <main class="utility-main">
 <section class="utility-hero">
 <h1>HTML to Markdown Converter</h1>

--- a/free-utilities/credit-card-validator/index.html
+++ b/free-utilities/credit-card-validator/index.html
@@ -20,7 +20,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <main class="utility-main">
 <section class="utility-hero">
 <h1>Credit Card Validator and Generator</h1>

--- a/free-utilities/csv-json-converter/index.html
+++ b/free-utilities/csv-json-converter/index.html
@@ -23,7 +23,7 @@
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-        <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+        <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
       </ul>
     </nav>
   </header>

--- a/free-utilities/generate-test-data/index.html
+++ b/free-utilities/generate-test-data/index.html
@@ -20,7 +20,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <main class="utility-main">
 <section class="utility-hero">
 <h1>Fake Data Generator Tool</h1>

--- a/free-utilities/html-beautifier/index.html
+++ b/free-utilities/html-beautifier/index.html
@@ -24,7 +24,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <nav>
         <ul>
             <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-            <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+            <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
         </ul>
     </nav>
 </header>

--- a/free-utilities/index.html
+++ b/free-utilities/index.html
@@ -216,7 +216,7 @@
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-        <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+        <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
       </ul>
     </nav>
   </header>

--- a/free-utilities/json-formatter-validator/index.html
+++ b/free-utilities/json-formatter-validator/index.html
@@ -22,7 +22,7 @@
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-        <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+        <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
       </ul>
     </nav>
   </header>

--- a/free-utilities/regex-tester/index.html
+++ b/free-utilities/regex-tester/index.html
@@ -24,7 +24,7 @@
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-        <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+        <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
       </ul>
     </nav>
   </header>

--- a/free-utilities/text-diff-checker/index.html
+++ b/free-utilities/text-diff-checker/index.html
@@ -25,7 +25,7 @@
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-        <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+        <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
       </ul>
     </nav>
   </header>

--- a/free-utilities/uuid-ulid-generator/index.html
+++ b/free-utilities/uuid-ulid-generator/index.html
@@ -23,7 +23,7 @@
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-        <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+        <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
       </ul>
     </nav>
   </header>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/index_files/ads.html
+++ b/index_files/ads.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/index_files/aframe.html
+++ b/index_files/aframe.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/index_files/aframe_data/sodar.html
+++ b/index_files/aframe_data/sodar.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/index_files/sh.html
+++ b/index_files/sh.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/index_files/zrt_lookup.html
+++ b/index_files/zrt_lookup.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/index_files/zrt_lookup_002.html
+++ b/index_files/zrt_lookup_002.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/index_files/zrt_lookup_003.html
+++ b/index_files/zrt_lookup_003.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/index_files/zrt_lookup_003/index.html
+++ b/index_files/zrt_lookup_003/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
     <article>
         <header>
             <h1>Understanding the ZRT Lookup 003 in Index Files</h1>

--- a/interview/linux-interview-questions-answers/index.html
+++ b/interview/linux-interview-questions-answers/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/commonly-used-netezza-basic-commands/index.html
+++ b/learn/commonly-used-netezza-basic-commands/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learn: Commonly Used Netezza Basic Commands</h1>
 <h2 id="connecting-to-netezza-database">1. Connecting to Netezza Database</h2>
 <pre><code>zConnect -h &lt;hostname&gt; -p &lt;port&gt; -U &lt;username&gt; -d &lt;database_name&gt;</code></pre>

--- a/learn/computing-architecture-terms/index.html
+++ b/learn/computing-architecture-terms/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/distribution-key-in-netezza/index.html
+++ b/learn/distribution-key-in-netezza/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learn: Distribution Key in Netezza</h1>
 <h2>Distribution, Not Just for Joins</h2>
 <p>There are several other scenarios where data needs to be distributed to process. One that comes to mind is count distincts. For example, a count of distinct users or customers like `count(distinct customer_id)` perhaps when doing analysis on purchase transactions. An example SQL might be:</p>

--- a/learn/error-recursion-detected-in-view-expansion/index.html
+++ b/learn/error-recursion-detected-in-view-expansion/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding and Resolving "Recursion Detected in View Expansion" Error in Ruby on Rails</h1>
 <section id="introduction">
 <h2>Introduction</h2>

--- a/learn/full-course/2d-animation/index.html
+++ b/learn/full-course/2d-animation/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/3d-animation/index.html
+++ b/learn/full-course/3d-animation/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/ansible/index.html
+++ b/learn/full-course/ansible/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/apache-cassandra/index.html
+++ b/learn/full-course/apache-cassandra/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Apache Cassandra - Full Course</h1>
 <section>
 <h2>Table of Contents</h2>

--- a/learn/full-course/aws-glue-serverless-etl/index.html
+++ b/learn/full-course/aws-glue-serverless-etl/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <footer>
 <h3>Meet Ananth Tirumanur. Hi there 👋</h3>
 <h4>I work on projects in data science, big data, data engineering, data modeling, software engineering, and system design.</h4>

--- a/learn/full-course/bootstrap/index.html
+++ b/learn/full-course/bootstrap/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Bootstrap - Full Course</h1>
 <h2>Module 1: Introduction to Bootstrap</h2>
 <ul>

--- a/learn/full-course/cplusplus/index.html
+++ b/learn/full-course/cplusplus/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/data-science-master-program/index.html
+++ b/learn/full-course/data-science-master-program/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/emc-storage/index.html
+++ b/learn/full-course/emc-storage/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>EMC Storage - Full Course</h1>
 <h2>Module 1: Storage Fundamentals</h2>
 <ol>

--- a/learn/full-course/etl-testing/index.html
+++ b/learn/full-course/etl-testing/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/ibm-cognos-tm1/index.html
+++ b/learn/full-course/ibm-cognos-tm1/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>IBM Cognos TM1 - Full Course</h1>
 <h2>Module 1: Introduction to IBM Cognos TM1</h2>
 <ul>

--- a/learn/full-course/ibm-mainframe-developer/index.html
+++ b/learn/full-course/ibm-mainframe-developer/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>IBM Mainframe Developer Full Course</h1>
 <h2>Introduction</h2>
 <p>Welcome to the IBM Mainframe Developer Full Course! In this comprehensive guide, we will take a deep dive into the world of IBM Z (formerly known as IBM Mainframe) and learn how to develop applications for this powerful platform. Whether you are new to mainframes or an experienced developer looking to expand your skillset, this course is designed to help you master the essential skills required to become a proficient IBM Mainframe Developer.</p>

--- a/learn/full-course/javascript/index.html
+++ b/learn/full-course/javascript/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/microsoft-advanced-excel/index.html
+++ b/learn/full-course/microsoft-advanced-excel/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Microsoft Advanced Excel - Full Course</h1>
 <p>This comprehensive course will take you through the advanced functionalities of Microsoft Excel, covering a wide range of topics from basic to advanced.</p>
 <h2>Module 1: Overview of the Basics of Excel</h2>

--- a/learn/full-course/microsoft-office/index.html
+++ b/learn/full-course/microsoft-office/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/mobile-application-testing/index.html
+++ b/learn/full-course/mobile-application-testing/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Mobile Application Testing - Full Course</h1>
 <p>Reading Time: Less than 1 minute</p>
 <h2>Module 1 : Introduction to Mobile Application Testing</h2>

--- a/learn/full-course/netapp-storage/index.html
+++ b/learn/full-course/netapp-storage/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>NetApp Storage - Full Course</h1>
 <p>Reading Time:  4 minutes</p>
 <h2>Module 1: The NetApp Storage Environment</h2>

--- a/learn/full-course/netezza/index.html
+++ b/learn/full-course/netezza/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learn Full Course: Netezza</h1>
 <ul>
 <li><a href="https://www.iexpertify.com/learn/full-course/netezza-overview/">IBM Netezza Overview</a></li>

--- a/learn/full-course/obiee/index.html
+++ b/learn/full-course/obiee/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>OBIEE - Full Course</h1>
 <h2>Module 1:</h2>
 <ul>

--- a/learn/full-course/oracle-admin/index.html
+++ b/learn/full-course/oracle-admin/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/oracle-apex/index.html
+++ b/learn/full-course/oracle-apex/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/oracle-apps-finance/index.html
+++ b/learn/full-course/oracle-apps-finance/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1> Oracle Apps Finance - Full Course</h1>
 <p>This comprehensive course covers various modules of Oracle Apps Finance, offering a deep dive into the primary functions, Entity Relationship Diagrams (ERDs), applications technology, and more.</p>
 <h2>Module 1: Course Overview</h2>

--- a/learn/full-course/oracle-apps-scm/index.html
+++ b/learn/full-course/oracle-apps-scm/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/oracle-dba/index.html
+++ b/learn/full-course/oracle-dba/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Oracle DBA Full Course: Become a Certified Oracle Database Administrator</h1>
 <p>Welcome to our comprehensive guide on the Oracle DBA (Database Administrator) full course! In this article, we'll walk you through the essential steps for becoming an Oracle DBA and achieving Oracle Database Administration Certification. This in-depth tutorial covers everything from basic concepts to advanced topics.</p>
 <h2 id="oracle-dba-roles-and-responsibilities">1. Understanding Roles and Responsibilities of Oracle DBAs</h2>

--- a/learn/full-course/oracle-forms-and-reports/index.html
+++ b/learn/full-course/oracle-forms-and-reports/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 
 <h1 id="oracle-forms-and-reports">Oracle Forms and Reports: A Comprehensive Guide</h1>
 <p>Oracle Forms and Reports are powerful tools for building robust, scalable, and user-friendly business applications. In this article, we will explore the fundamentals of Oracle Forms and Reports, covering topics such as architecture, components, and best practices.</p>

--- a/learn/full-course/oracle-fusion-hcm/index.html
+++ b/learn/full-course/oracle-fusion-hcm/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1> Oracle Fusion HCM - Full Course </h1>
 <p> Below is the comprehensive syllabus for our Oracle Fusion HCM course:</p>
 <ol>

--- a/learn/full-course/oracle-sql-and-plsql/index.html
+++ b/learn/full-course/oracle-sql-and-plsql/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/pega/index.html
+++ b/learn/full-course/pega/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <footer>
 <h3>Meet Ananth Tirumanur. Hi there 👋</h3>
 <h4>I work on projects in data science, big data, data engineering, data modeling, software engineering, and system design.</h4>

--- a/learn/full-course/php-mysql/index.html
+++ b/learn/full-course/php-mysql/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>PHP &amp; MySQL Full Course</h1>
 <h2>Introduction</h2>
 <p>Welcome to our PHP and MySQL full course! In this comprehensive guide, we will learn about both PHP and MySQL, starting from the basics and moving on to more advanced topics.</p>

--- a/learn/full-course/python-with-machine-learning/index.html
+++ b/learn/full-course/python-with-machine-learning/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/qtp/index.html
+++ b/learn/full-course/qtp/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/react-js/index.html
+++ b/learn/full-course/react-js/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/salesforce-admin/index.html
+++ b/learn/full-course/salesforce-admin/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/salesforce/index.html
+++ b/learn/full-course/salesforce/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/sap-bi-bw/index.html
+++ b/learn/full-course/sap-bi-bw/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/sap-crm/index.html
+++ b/learn/full-course/sap-crm/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Full Course: SAP CRM</h1>
 <h2>Module 1: Overview of CRM Architecture</h2>
 <ul>

--- a/learn/full-course/sap-pm/index.html
+++ b/learn/full-course/sap-pm/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/sap-qm/index.html
+++ b/learn/full-course/sap-qm/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>SAP QM - Full Course</h1>
 <h2>Module 1: Enterprise Structure</h2>
 <ul>

--- a/learn/full-course/sap-s4-hana/index.html
+++ b/learn/full-course/sap-s4-hana/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/sap-security-grc/index.html
+++ b/learn/full-course/sap-security-grc/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>SAP Security GRC - Full Course</h1>
 <p>This comprehensive course covers SAP Security GRC (Governance, Risk, and Compliance).</p>
 <h2>SAP Security:</h2>

--- a/learn/full-course/sap-ui5-fiori/index.html
+++ b/learn/full-course/sap-ui5-fiori/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Full Course: Learning SAP UI5 Fiori</h1>
 <h2>Introduction</h2>
 <p>Welcome to our comprehensive course on SAP UI5 Fiori! This course is designed for developers who want to learn how to create amazing user interfaces using the SAP UI5 framework. By the end of this course, you'll be able to build your own Fiori applications.</p>

--- a/learn/full-course/sap-wm-ewm/index.html
+++ b/learn/full-course/sap-wm-ewm/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>SAP EWM and WM Course Outline</h1>
 <h2>SAP WM</h2>
 <ul>

--- a/learn/full-course/sharepoint-developer/index.html
+++ b/learn/full-course/sharepoint-developer/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>SharePoint Developer - Full Course</h1>
 <h2>Module 1: SharePoint 2013 Fundamentals</h2>
 <ul>

--- a/learn/full-course/soa-testing/index.html
+++ b/learn/full-course/soa-testing/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/spoken-english/index.html
+++ b/learn/full-course/spoken-english/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Spoken English - Full Course</h1>
 <p>Reading Time: Approximately 1 minute</p>
 <ol>

--- a/learn/full-course/spring/index.html
+++ b/learn/full-course/spring/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/tableau-software/index.html
+++ b/learn/full-course/tableau-software/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/tally/index.html
+++ b/learn/full-course/tally/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/teradata-dba/index.html
+++ b/learn/full-course/teradata-dba/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Teradata DBA - Full Course</h1>
 <h2 id="module-1">Module 1: Teradata Architecture</h2>
 <ul>

--- a/learn/full-course/teradata/index.html
+++ b/learn/full-course/teradata/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <article>
 <h1>Teradata - Full Course</h1>
 <p>Reading Time: Approx. 3 minutes</p>

--- a/learn/full-course/tibco-spotfire/index.html
+++ b/learn/full-course/tibco-spotfire/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>TIBCO Spotfire - Full Course</h1>
 <p>Reading Time: Approx. 10 minutes</p>
 <h2>Module 1: Spotfire Basic Skills</h2>

--- a/learn/full-course/ui-path/index.html
+++ b/learn/full-course/ui-path/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/vmware-cloud/index.html
+++ b/learn/full-course/vmware-cloud/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/full-course/workday/index.html
+++ b/learn/full-course/workday/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Full Course on Workday</h1>
 <h2 id="module-1-&amp;-2">Module 1 &amp; 2: Core Concepts and Navigation Basics</h2>
 <ul>

--- a/learn/how-to-connect-netezza-using-jdbc-driver-and-working-examples/index.html
+++ b/learn/how-to-connect-netezza-using-jdbc-driver-and-working-examples/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learn: How to Connect Netezza using JDBC Driver and Working Examples</h1>
 <p>Explore the process of connecting to Netezza by utilizing various methods and programming languages. Netezza supports ODBC, OLEDB, and JDBC drivers for connections.</p>
 <h2 id="Before_you_begin">Before you begin</h2>

--- a/learn/how-to-undo-a-delete-update-or-insert-in-netezza/index.html
+++ b/learn/how-to-undo-a-delete-update-or-insert-in-netezza/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Undoing Deletes, Updates, or Inserts in Netezza</h1>
 <p>In Netezza, it is crucial to comprehend the concept of transaction ids (xids) when dealing with data manipulation operations such as delete, update, or insert.</p>
 <h3>Understanding Transaction Ids</h3>

--- a/learn/is-netezza-near-end-of-life/index.html
+++ b/learn/is-netezza-near-end-of-life/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Is Netezza Near End of Life? A Comprehensive Guide</h1>
 <h2>Introduction</h2>
 <p>Netezza, a high-performance data warehouse solution developed by IBM, has been a popular choice for many organizations due to its scalability and powerful analytics capabilities. However, questions about the future of Netezza have arisen with IBM's recent strategic shifts. This article aims to clarify the current status and potential future of Netezza.</p>

--- a/learn/list-of-netezza-data-types-and-best-practices/index.html
+++ b/learn/list-of-netezza-data-types-and-best-practices/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <article>
 <h1>Learn: List of Netezza Data Types and Best Practices</h1>
 <section id="Netezza_Data_Types">

--- a/learn/local-external-tables-netezza/index.html
+++ b/learn/local-external-tables-netezza/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learning Local and External Tables in Netezza</h1>
 <p>When your query generates a substantial amount of results and takes over an hour to execute, consider utilizing local external tables. This technique is beneficial for queries that require large data sets.</p>
 <h2>Tool Selection</h2>

--- a/learn/manually-failover-a-disk-in-netezza/index.html
+++ b/learn/manually-failover-a-disk-in-netezza/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Manually Failover a Disk in Netezza</h1>
 <p>Follow these steps to manually failover a disk in Netezza:</p>
 <ol>

--- a/learn/materialized-views-in-netezza/index.html
+++ b/learn/materialized-views-in-netezza/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learning Materialized Views in Netezza</h1>
 <h2>Introduction</h2>
 <p>Materialized views are a powerful tool for improving the performance of complex queries in databases, and Netezza is no exception. In this article, we will explore how to create and use materialized views in Netezza.</p>

--- a/learn/netezza-ampp-architecture/index.html
+++ b/learn/netezza-ampp-architecture/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Netezza AMPP Architecture - learn</h1>
 <nav id="toc">
 <a class="lwptoc_toggle_label" data-label="show" href="#">hide</a>

--- a/learn/netezza-architecture/index.html
+++ b/learn/netezza-architecture/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Netezza Architecture: A Comprehensive Overview</h1>
 <p>In this article, we'll delve into the Netezza architecture and explore its components, benefits, and challenges. If you're new to Netezza or looking to deepen your understanding of this powerful data warehouse platform, read on!</p>
 <h2>Overview of Netezza Architecture</h2>

--- a/learn/netezza-backups-status-showing-active-2/index.html
+++ b/learn/netezza-backups-status-showing-active-2/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learn: Netezza Backups Status Showing Active</h1>
 <p>In this article, we will discuss how to find database backup time in a Netezza environment, troubleshoot when the backup status shows active, and provide useful queries for tracking backups.
        </p>

--- a/learn/netezza-best-practices-to-improve-performance/index.html
+++ b/learn/netezza-best-practices-to-improve-performance/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <div class="container">
 <h1 class="title">Best Practices for Improving Netezza Performance</h1>
 <section class="section-item" id="Optimizing_Query_Structure">

--- a/learn/netezza-create-view-syntax-and-examples/index.html
+++ b/learn/netezza-create-view-syntax-and-examples/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learning Netezza: Create View Syntax and Examples</h1>
 <p>In this article, we will delve into the process of creating views in Netezza, a high-performance data warehouse database system. Views serve as virtual tables based on the result-set of an SQL statement. They can simplify complex queries, enhance security, and promote better organization of your database schema.</p>
 <h2>Syntax</h2>

--- a/learn/netezza-cross-database-access-and-its-restrictions/index.html
+++ b/learn/netezza-cross-database-access-and-its-restrictions/index.html
@@ -16,7 +16,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Netteza Cross-Database Access and its Restrictions</h1>
 <p>In this article, we will explore Netezza's cross-database access feature and its restrictions. Understanding these concepts is crucial for efficient data management in a multi-database environment.</p>
 <h2>What is Cross-Database Access?</h2>

--- a/learn/netezza-databases-tables-and-database-objects/index.html
+++ b/learn/netezza-databases-tables-and-database-objects/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learning about Netezza Databases, Tables, and Database Objects</h1>
 <p>This article provides an overview of the major object groups in Netezza, including Users, User Groups, Tables, Views, Materialized Views, Synonyms, Databases, Procedures, and User Defined Functions. If you are familiar with other relational database management systems, you'll notice that there are no indexes, bufferpools, or tablespaces to manage in Netezza.</p>
 <h2 id="Netezza Database Objects">Netezza Database Objects</h2>

--- a/learn/netezza-default-port-numbers/index.html
+++ b/learn/netezza-default-port-numbers/index.html
@@ -30,7 +30,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/netezza-distribute-on/index.html
+++ b/learn/netezza-distribute-on/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learn: Netezza Distribute on</h1>
 <p class="has-drop-cap">When creating tables in databases and storing data, the data gets allocated into disk extents. Netezza distributes this data across all available data slices based on the specified distribution key during table creation. A maximum of four columns can be used as a distribution key if you prefer not to distribute randomly.</p>
 <p class="has-drop-cap">If a specific column is chosen for distribution, Netezza uses this column's data to distribute the records across dataslices using hashing. When random is selected as the option for data distribution, the appliance employs a round robin algorithm to distribute data evenly.</p>

--- a/learn/netezza-failover-high-availability-architecture/index.html
+++ b/learn/netezza-failover-high-availability-architecture/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding Netezza Failover High Availability Architecture</h1>
 <p>Netezza, as an appliance, is equipped with essential failover components to ensure smooth operation even in the face of hardware issues. This architecture guarantees an availability rate exceeding 99.99%. Two hosts constitute a cluster in every Netezza appliance, enabling seamless takeover if one host encounters a failure.</p>
 <p>Netezza leverages Linux-HA (High Availability) and Distributed Replicated Block Device for managing the host cluster and data mirroring between these hosts respectively.</p>

--- a/learn/netezza-generate-statistics-a-guide-and-best-practices/index.html
+++ b/learn/netezza-generate-statistics-a-guide-and-best-practices/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Generate Statistics in Netezza: A Guide and Best Practices</h1>
 <p>In this article, we delve into the world of generating statistics in Netezza, a powerful analytics platform. We'll cover the basics, best practices, and provide code samples to help you optimize your data analysis.</p>
 <section id="what-are-statistics">

--- a/learn/netezza-mako-appliance-latest-netezza-powered-dwh-appliance/index.html
+++ b/learn/netezza-mako-appliance-latest-netezza-powered-dwh-appliance/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <p>Netezza Mako Appliance - A Comprehensive Guide</p>
 <a class="wp-block-button__link" href="https://www.iexpertify.com/learn/full-course/netezza/" style="background:linear-gradient(to right, luminous-vivid-amber, luminous-vivid-orange); color:white; border-radius:50px">Explore Free Netezza Course</a>
 <p>IBM Netezza Mako server is the latest appliance in the IBM PureData System for Analytics system, powered by Netezza technology. Due to the phase-out of support for these appliances by IBM, it is recommended to transition towards cloud-based Netezza solutions or on-premises solutions that can be installed on container workloads on general Linux servers.</p>

--- a/learn/netezza-monitor-grown-defects-on-disks/index.html
+++ b/learn/netezza-monitor-grown-defects-on-disks/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learn: Monitor Grown Defects on Disks in Netezza</h1>
 <p><strong>Estimated Reading Time:</strong> Less than 1 minute</p>
 <h2>SQL to Monitor Disk Defects for TwinFin Architecture</h2>

--- a/learn/netezza-nzstats-command-and-usage/index.html
+++ b/learn/netezza-nzstats-command-and-usage/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <p>Learn about the <strong>nzstats</strong> Command in Netezza:</p>
 <p>The nzstats command is a powerful tool that allows you to display group and statistics tables. To view IBM® Netezza® statistics, you must be the user 'admin' or have Manage System privileges. Additionally, you must be the user 'admin' to view the Database, Table, and Query tables.</p>
 <p>Netezza appliances leverage up-to-date statistic information for planning and executing queries. The statistics are crucial in ensuring optimal query performance.</p>

--- a/learn/netezza-out-of-range-error/index.html
+++ b/learn/netezza-out-of-range-error/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <article>
 <h1>Learning about Netezza: Out of Range Error</h1>
 <p>Estimated Reading Time: &lt; 1 minute</p>

--- a/learn/netezza-overview/index.html
+++ b/learn/netezza-overview/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learn: An Overview of Netezza</h1>
 <p>Welcome to our comprehensive guide on Netezza! This article will provide an in-depth overview of IBM's advanced analytics and warehousing solution, now rebranded as IBM PureData for Analytics (PDA).</p>
 <ul>

--- a/learn/netezza-query-history-details-using-nz_query_history-table/index.html
+++ b/learn/netezza-query-history-details-using-nz_query_history-table/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Accessing Netezza Query History Details Using nz_query_history Table</h1>
 <section>
 <h2>Prerequisites</h2>

--- a/learn/netezza-query-plan-analysis/index.html
+++ b/learn/netezza-query-plan-analysis/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learning Netezza Query Plan Analysis</h1>
 <p>Analyzing the Netezza query plan is a crucial step in optimizing your queries for better performance. In this article, we'll delve into the world of Netezza query plans and explore how to analyze them to improve query execution.</p>
 <h2>What is a Query Plan?</h2>

--- a/learn/netezza-security/index.html
+++ b/learn/netezza-security/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/netezza-sequence-and-create-use-it/index.html
+++ b/learn/netezza-sequence-and-create-use-it/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learning Netezza: Sequence, Create, and Use It</h1>
 <h2>Introduction</h2>
 

--- a/learn/netezza-storage/index.html
+++ b/learn/netezza-storage/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding Netezza Storage</h1>
 <section id="overview">
 <h2>Overview of Netezza Storage Disks</h2>

--- a/learn/netezza-system-tables-and-views/index.html
+++ b/learn/netezza-system-tables-and-views/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Netezza System Tables and Views</h1>
 <p>Understanding the system tables and views in Netezza is crucial for database administrators, developers, and data analysts working with this powerful data warehouse platform. In this article, we will explore various system tables and views available in Netezza.</p>
 <h2>System Tables</h2>

--- a/learn/netezza-temporary-table-space/index.html
+++ b/learn/netezza-temporary-table-space/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Mastering Netezza Temporary Table Space: A Comprehensive Guide</h1>
 <p>Netezza, a powerful data warehousing and analytics platform, offers temporary table space as a valuable feature to enhance its performance and scalability. In this article, we'll delve into the world of Netezza temporary table space, exploring its benefits, use cases, and best practices for optimal usage.</p>
 <h2>What is Netezza Temporary Table Space?</h2>

--- a/learn/netezza-transaction-management-begin-commit-rollback/index.html
+++ b/learn/netezza-transaction-management-begin-commit-rollback/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <article class="article">
 <h1 class="title">Understanding Transaction Management in Netezza</h1>
 <section class="content">

--- a/learn/netezza-twinfin-architecture/index.html
+++ b/learn/netezza-twinfin-architecture/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Netezza Architecture Overview</h1>
 <h2>TwinFin 12 Components:</h2>
 <ul>

--- a/learn/netezza-zone-maps-best-practices/index.html
+++ b/learn/netezza-zone-maps-best-practices/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <article class="wp-content-typed">
 <h1>Netezza Zone Maps Best Practices - learn</h1>
 <p>Reading Time:  5 minutes</p>

--- a/learn/nzstop-vs-nzsystem-stop/index.html
+++ b/learn/nzstop-vs-nzsystem-stop/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/learn/script-to-find-netezza-database-size/index.html
+++ b/learn/script-to-find-netezza-database-size/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Script to Find Netezza Database Size</h1>
 <p>In this article, we will explore a script that helps you find the size of a Netezza database. This is useful for capacity planning and performance monitoring.</p>
 <h2>Prerequisites</h2>

--- a/learn/smp-vs-mpp-architecture/index.html
+++ b/learn/smp-vs-mpp-architecture/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>SMP vs MPP Architecture - learn</h1>
 <h2 id="Databases_such_as_Oracle_DB2_Sybase">1) Databases such as Oracle, DB2, Sybase</h2>
 <p>The Symmetrical Multi-Processing (SMP) Architecture was once the champion of Data Warehousing. However, it faced several disadvantages:</p>

--- a/learn/sql-to-find-all-resource-groups-in-netezza/index.html
+++ b/learn/sql-to-find-all-resource-groups-in-netezza/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learn: SQL to Find All Resource Groups in Netezza</h1>
 <p>In this guide, you will learn how to use SQL queries to find all the Resource Groups in a Netezza system. This is particularly useful when you want to manage your resources efficiently and optimize database performance.</p>
 <h2>Prerequisites</h2>

--- a/learn/steps-to-restore-table-in-netezza/index.html
+++ b/learn/steps-to-restore-table-in-netezza/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Steps to Restore a Table in Netezza</h1>
 <p>This guide will walk you through the process of restoring a table in Netezza.</p>
 <ol>

--- a/learn/to-remove-the-bogus-sas-switch-entries-netezza/index.html
+++ b/learn/to-remove-the-bogus-sas-switch-entries-netezza/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Learn: How to Remove Bogus SAS Switch Entries in Netezza</h1>
 <p>In this guide, we will walk you through the process of removing bogus SAS switch entries from Netezza. This is an important step towards optimizing your SQL code and improving performance when working with large datasets.</p>
 <h2>Understanding Bogus SAS Switch Entries</h2>

--- a/linux/grep_regex_example_linux/index.html
+++ b/linux/grep_regex_example_linux/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/linux/input-output-redirection-in-linux-unix-examples/index.html
+++ b/linux/input-output-redirection-in-linux-unix-examples/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Input Redirection in Linux/Unix: A Comprehensive Guide with Examples</h1>
 <p>
             Discover the power of input redirection—a fundamental feature of Linux/Unix systems that enables users to control data flow seamlessly between commands, files, and processes. In this article, we'll walk through the basics of input redirection, supplemented with practical examples, tips, and FAQs, making you a command-line pro in no time!

--- a/linux/linux-ls-command/index.html
+++ b/linux/linux-ls-command/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Understanding the Linux/Linux ls Command</h1>
 <p>The LS command is a fundamental tool in the Linux operating system. Its basic syntax is:</p>
 <pre><code>ls [option] [path_to_file/directory]</code></pre>

--- a/linux/linux-man-command-manual/index.html
+++ b/linux/linux-man-command-manual/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>The man Command in Linux: A Comprehensive Manual (Manual)</h1>
 <p>Welcome to our exploration of the man command, a versatile tool that opens up a world of information about various commands and utilities in Linux. Whether you're a beginner or an experienced user, mastering the man command can significantly deepen your understanding of system utilities and optimize your command-line experience.</p>
 <h2>Understanding the man Command</h2>

--- a/linux/simple-linux-commands/index.html
+++ b/linux/simple-linux-commands/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 
 <table><thead><tr><th>Command</th><th>Description</th></tr></thead><tbody>
 <td>ls</td>

--- a/lp-profile/index.html
+++ b/lp-profile/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>LP Profile - iexpertify</h1>
 <section class="site-content" id="content">
 <div class="container">

--- a/tag/linux/index.html
+++ b/tag/linux/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index.html
+++ b/tag/linux/page/2/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/ads.html
+++ b/tag/linux/page/2/index_files/ads.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/ads_004.html
+++ b/tag/linux/page/2/index_files/ads_004.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/aframe.html
+++ b/tag/linux/page/2/index_files/aframe.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/ads.html
+++ b/tag/linux/page/2/index_files/index_files/ads.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/ads_004.html
+++ b/tag/linux/page/2/index_files/index_files/ads_004.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/aframe.html
+++ b/tag/linux/page/2/index_files/index_files/aframe.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/ads.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/ads.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/ads_004.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/ads_004.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/aframe.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/aframe.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/ads.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/ads.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/ads_004.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/ads_004.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/aframe.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/aframe.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/ads.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/ads.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/ads_004.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/ads_004.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/aframe.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/aframe.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/ads.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/ads.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/ads_004.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/ads_004.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/aframe.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/aframe.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/sh.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/sh.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/zrt_lookup.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/zrt_lookup.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/zrt_lookup_002.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/zrt_lookup_002.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/zrt_lookup_003.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/index_files/zrt_lookup_003.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/sh.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/sh.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/zrt_lookup.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/zrt_lookup.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/zrt_lookup_002.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/zrt_lookup_002.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/zrt_lookup_003.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/index_files/zrt_lookup_003.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/sh.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/sh.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/zrt_lookup.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/zrt_lookup.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/zrt_lookup_002.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/zrt_lookup_002.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/index_files/zrt_lookup_003.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/index_files/zrt_lookup_003.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/sh.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/sh.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/zrt_lookup.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/zrt_lookup.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/zrt_lookup_002.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/zrt_lookup_002.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/index_files/zrt_lookup_003.html
+++ b/tag/linux/page/2/index_files/index_files/index_files/zrt_lookup_003.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/sh.html
+++ b/tag/linux/page/2/index_files/index_files/sh.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/zrt_lookup.html
+++ b/tag/linux/page/2/index_files/index_files/zrt_lookup.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/zrt_lookup_002.html
+++ b/tag/linux/page/2/index_files/index_files/zrt_lookup_002.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/index_files/zrt_lookup_003.html
+++ b/tag/linux/page/2/index_files/index_files/zrt_lookup_003.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/sh.html
+++ b/tag/linux/page/2/index_files/sh.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/zrt_lookup.html
+++ b/tag/linux/page/2/index_files/zrt_lookup.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/zrt_lookup_002.html
+++ b/tag/linux/page/2/index_files/zrt_lookup_002.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/linux/page/2/index_files/zrt_lookup_003.html
+++ b/tag/linux/page/2/index_files/zrt_lookup_003.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/feed/index.html
+++ b/tag/netezza/feed/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/index.html
+++ b/tag/netezza/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Discovering the Power of Netezza: A Comprehensive Guide to Tags</h1>
 <p>Netezza, a potent data warehousing platform, has been transforming the way organizations manage large-scale data processing and analysis. To help demystify this technology, we will venture into the realm of Netezza tags – vital for optimizing query performance and streamlining your data manipulation tasks.</p>
 <h2>What are Netezza Tags?</h2>

--- a/tag/netezza/page/6/index.html
+++ b/tag/netezza/page/6/index.html
@@ -28,7 +28,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/ads.html
+++ b/tag/netezza/page/6/index_files/ads.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/ads_004.html
+++ b/tag/netezza/page/6/index_files/ads_004.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/aframe.html
+++ b/tag/netezza/page/6/index_files/aframe.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/ads.html
+++ b/tag/netezza/page/6/index_files/index_files/ads.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/ads_004.html
+++ b/tag/netezza/page/6/index_files/index_files/ads_004.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/aframe.html
+++ b/tag/netezza/page/6/index_files/index_files/aframe.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/ads.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/ads.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/ads_004.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/ads_004.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/aframe.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/aframe.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/ads.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/ads.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/ads_004.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/ads_004.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/aframe.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/aframe.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/ads.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/ads.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/ads_004.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/ads_004.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/aframe.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/aframe.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/ads.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/ads.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/ads_004.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/ads_004.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/aframe.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/aframe.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/sh.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/sh.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/zrt_lookup.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/zrt_lookup.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/zrt_lookup_002.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/zrt_lookup_002.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/zrt_lookup_003.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/index_files/zrt_lookup_003.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/sh.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/sh.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/zrt_lookup.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/zrt_lookup.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/zrt_lookup_002.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/zrt_lookup_002.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/zrt_lookup_003.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/index_files/zrt_lookup_003.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/sh.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/sh.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/zrt_lookup.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/zrt_lookup.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/zrt_lookup_002.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/zrt_lookup_002.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/index_files/zrt_lookup_003.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/index_files/zrt_lookup_003.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/sh.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/sh.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/zrt_lookup.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/zrt_lookup.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/zrt_lookup_002.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/zrt_lookup_002.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/index_files/zrt_lookup_003.html
+++ b/tag/netezza/page/6/index_files/index_files/index_files/zrt_lookup_003.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/sh.html
+++ b/tag/netezza/page/6/index_files/index_files/sh.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/zrt_lookup.html
+++ b/tag/netezza/page/6/index_files/index_files/zrt_lookup.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/zrt_lookup_002.html
+++ b/tag/netezza/page/6/index_files/index_files/zrt_lookup_002.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/index_files/zrt_lookup_003.html
+++ b/tag/netezza/page/6/index_files/index_files/zrt_lookup_003.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/sh.html
+++ b/tag/netezza/page/6/index_files/sh.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/zrt_lookup.html
+++ b/tag/netezza/page/6/index_files/zrt_lookup.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/zrt_lookup_002.html
+++ b/tag/netezza/page/6/index_files/zrt_lookup_002.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/tag/netezza/page/6/index_files/zrt_lookup_003.html
+++ b/tag/netezza/page/6/index_files/zrt_lookup_003.html
@@ -17,7 +17,7 @@
         <nav>
             <ul>
                 <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
-                <li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
+                <li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li>
             </ul>
         </nav>
     </header>

--- a/temp/temp-testing/what-is-requirements-traceability-matrix-rtm-example-template/index.html
+++ b/temp/temp-testing/what-is-requirements-traceability-matrix-rtm-example-template/index.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Requirements Traceability Matrix (RTM) and its Example Template</h1>
 <p>A Requirements Traceability Matrix (RTM) is a document that shows the relationship between different types of software requirements, such as business, functional, system, and test requirements. It provides a structured means to verify that each requirement has been addressed in the final product and helps in ensuring traceability throughout the software development life cycle (SDLC).</p>
 <h2>Why is Requirements Traceability Matrix important?</h2>

--- a/update_html.py
+++ b/update_html.py
@@ -18,7 +18,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 '''
 
 footer = '''<footer>

--- a/update_html_md.py
+++ b/update_html_md.py
@@ -18,7 +18,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 '''
 
 footer = '''<footer>

--- a/upskill/netezza-sequence-and-create-use-it/index.html
+++ b/upskill/netezza-sequence-and-create-use-it/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <h1>Mastering Netezza Sequences and How to Use Them</h1>
 <section id="introduction">
 <h2>Introduction</h2>


### PR DESCRIPTION
### Motivation
- Standardize site navigation so every page header includes a `Courses` link (`https://www.iexpertify.com/courses/`) alongside existing nav items. 

### Description
- Updated the HTML header templates in `update_html.py` and `update_html_md.py` to include `<li><a href="https://www.iexpertify.com/courses/">Courses</a></li>` in the nav bar. 
- Performed a mechanical repo-wide update to add the same `Courses` nav item to existing generated and static pages, touching ~310 HTML files so current content matches the new template. 
- Removed ephemeral interpreter artifacts created during validation (`__pycache__` files) to keep repo clean. 

### Testing
- Ran `python -m py_compile update_html.py update_html_md.py` which completed successfully. 
- Verified representative pages via a small Python script that checked samples (`index.html`, `data-warehousing/datastage-file-stages/index.html`, `free-utilities/generate-test-data/index.html`) and confirmed both `Courses` and `Free Utilities` links are present. 
- Performed a repository-wide scan that returned `0` pages containing the `Free Utilities` link without the `Courses` link. 
- Started a local HTTP server and captured a browser screenshot to visually validate the updated header (artifact generated during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f2648f4688328a677d3ee23cc8256)