### PR TITLE
Standardize courses and free-utilities layout and shared header styling

### DIFF
--- a/assets/css/course-experience.css
+++ b/assets/css/course-experience.css
@@ -1,5 +1,8 @@
 .course-shell {
   max-width: 940px;
+  width: min(100%, 940px);
+  margin: 0 auto;
+  padding: 0 20px 32px;
 }
 
 .course-hero {

--- a/courses/athena-query-performance/index.html
+++ b/courses/athena-query-performance/index.html
@@ -10,7 +10,7 @@
 <body class="course-shell" data-course-manifest="/data/course-manifests/athena-query-performance.json">
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
-  <header>
+  <header class="site-header">
     <nav>
       <ul>
         <li><a href="/">iExpertify</a></li>

--- a/courses/databricks-troubleshooting/index.html
+++ b/courses/databricks-troubleshooting/index.html
@@ -10,7 +10,7 @@
 <body class="course-shell" data-course-manifest="/data/course-manifests/databricks-troubleshooting.json">
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
-  <header>
+  <header class="site-header">
     <nav>
       <ul>
         <li><a href="/">iExpertify</a></li>

--- a/courses/index.html
+++ b/courses/index.html
@@ -8,7 +8,7 @@
 <body class="course-shell">
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
-  <header>
+  <header class="site-header">
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>

--- a/courses/netezza-foundations/index.html
+++ b/courses/netezza-foundations/index.html
@@ -10,7 +10,7 @@
 <body class="course-shell" data-course-manifest="/data/course-manifests/netezza-foundations.json">
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
-  <header>
+  <header class="site-header">
     <nav>
       <ul>
         <li><a href="/">iExpertify</a></li>

--- a/free-utilities/aws-cloudformation-validator/index.html
+++ b/free-utilities/aws-cloudformation-validator/index.html
@@ -20,7 +20,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header>
+<header class="site-header">
     <nav>
         <ul>
             <li><a href="https://www.iexpertify.com/">iExpertify</a></li>

--- a/free-utilities/base64-encoder-decoder/index.html
+++ b/free-utilities/base64-encoder-decoder/index.html
@@ -18,7 +18,7 @@
 </head>
 <body>
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <header>
+  <header class="site-header">
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>

--- a/free-utilities/college-fit/index.html
+++ b/free-utilities/college-fit/index.html
@@ -45,7 +45,7 @@
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<header>
+<header class="site-header">
     <nav>
         <ul>
             <li><a href="https://www.iexpertify.com/">iExpertify</a></li>

--- a/free-utilities/combine-pdf/index.html
+++ b/free-utilities/combine-pdf/index.html
@@ -34,7 +34,7 @@
 <body>
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
-  <header>
+  <header class="site-header">
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>

--- a/free-utilities/convert-html-to-md/index.html
+++ b/free-utilities/convert-html-to-md/index.html
@@ -62,7 +62,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header class="site-header"><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <main class="utility-main">
 <section class="utility-hero">
 <h1>HTML to Markdown Converter</h1>

--- a/free-utilities/credit-card-validator/index.html
+++ b/free-utilities/credit-card-validator/index.html
@@ -20,7 +20,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header class="site-header"><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <main class="utility-main">
 <section class="utility-hero">
 <h1>Credit Card Validator and Generator</h1>

--- a/free-utilities/csv-json-converter/index.html
+++ b/free-utilities/csv-json-converter/index.html
@@ -19,7 +19,7 @@
 </head>
 <body>
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <header>
+  <header class="site-header">
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>

--- a/free-utilities/generate-test-data/index.html
+++ b/free-utilities/generate-test-data/index.html
@@ -20,7 +20,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
+<header class="site-header"><nav><ul><li><a href="https://www.iexpertify.com/">iExpertify</a></li><li><a href="https://www.iexpertify.com/courses/">Courses</a></li><li><a href="https://www.iexpertify.com/free-utilities/">Free Utilities</a></li></ul></nav></header>
 <main class="utility-main">
 <section class="utility-hero">
 <h1>Fake Data Generator Tool</h1>

--- a/free-utilities/html-beautifier/index.html
+++ b/free-utilities/html-beautifier/index.html
@@ -20,7 +20,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<header>
+<header class="site-header">
     <nav>
         <ul>
             <li><a href="https://www.iexpertify.com/">iExpertify</a></li>

--- a/free-utilities/index.html
+++ b/free-utilities/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <link href="/simplecss/styles.css" rel="stylesheet">
+  <link href="/free-utilities/utilities-theme.css" rel="stylesheet">
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -18,201 +19,13 @@
     gtag('config', 'G-VS67BGEQZW');
   </script>
   <title>Free Utilities - iExpertify</title>
-  <style>
-    :root {
-      --surface: #ffffff;
-      --surface-soft: #f8fafc;
-      --text-main: #0f172a;
-      --text-subtle: #475569;
-      --brand: #0f766e;
-      --brand-soft: #ccfbf1;
-      --border: #dce3eb;
-      --shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
-    }
-
-    body {
-      font-family: "Roboto", sans-serif;
-      background: linear-gradient(180deg, #f0fdfa 0%, #f8fafc 34%, #ffffff 100%);
-      color: var(--text-main);
-    }
-
-    header,
-    main,
-    footer {
-      max-width: 1100px;
-      margin: 0 auto;
-    }
-
-    header nav ul {
-      display: flex;
-      gap: 0.9rem;
-      list-style: none;
-      padding: 0.8rem 0;
-      margin: 0;
-      flex-wrap: wrap;
-    }
-
-    header nav a {
-      display: inline-block;
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 999px;
-      padding: 0.45rem 0.9rem;
-      text-decoration: none;
-      font-weight: 500;
-      color: var(--text-main);
-    }
-
-    .page-content {
-      padding: 1rem 0 2.5rem;
-    }
-
-    .hero {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      box-shadow: var(--shadow);
-      padding: 1.2rem 1.3rem;
-      margin-bottom: 1.2rem;
-    }
-
-    .hero h1 {
-      margin: 0 0 0.35rem;
-      font-size: 1.65rem;
-    }
-
-    .hero p {
-      margin: 0;
-      color: var(--text-subtle);
-    }
-
-    .tools-list {
-      list-style: none;
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 0.9rem;
-      padding: 0;
-      margin: 0 0 1.5rem;
-    }
-
-    .tools-list li a {
-      display: flex;
-      align-items: center;
-      gap: 0.7rem;
-      min-height: 76px;
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 14px;
-      box-shadow: var(--shadow);
-      color: var(--text-main);
-      text-decoration: none;
-      padding: 0.85rem 0.95rem;
-      transition: transform 0.15s ease, border-color 0.15s ease;
-    }
-
-    .tools-list li a:hover {
-      transform: translateY(-2px);
-      border-color: #99f6e4;
-    }
-
-    .tools-list .icon {
-      background: var(--brand-soft);
-      border-radius: 10px;
-      width: 42px;
-      height: 42px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 1.2rem;
-      flex-shrink: 0;
-    }
-
-    .tools-list .text {
-      color: var(--text-subtle);
-      line-height: 1.35;
-    }
-
-    .articles-section {
-      margin: 1.4rem 0 1.7rem;
-    }
-
-    .articles-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 0.85rem;
-    }
-
-    .article-card {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      overflow: hidden;
-      text-decoration: none;
-      color: inherit;
-      box-shadow: var(--shadow);
-      transition: transform 0.15s ease;
-    }
-
-    .article-card:hover {
-      transform: translateY(-2px);
-    }
-
-    .article-card img {
-      display: block;
-      width: 100%;
-      height: 120px;
-      object-fit: cover;
-    }
-
-    .article-card h4 {
-      margin: 0;
-      padding: 0.75rem;
-      font-size: 0.96rem;
-      line-height: 1.35;
-    }
-
-    footer {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      box-shadow: var(--shadow);
-      padding: 1rem 1.2rem 1.4rem;
-      margin-bottom: 2rem;
-    }
-
-    footer h1 {
-      font-size: 1.35rem;
-      margin: 0 0 0.45rem;
-    }
-
-    footer h2 {
-      font-size: 1.05rem;
-      color: var(--text-subtle);
-      margin: 0 0 0.8rem;
-      line-height: 1.4;
-    }
-
-    footer ul {
-      padding-left: 1.1rem;
-    }
-
-    @media (max-width: 640px) {
-      .hero h1 {
-        font-size: 1.35rem;
-      }
-
-      .tools-list {
-        grid-template-columns: 1fr;
-      }
-    }
-  </style>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
 
-  <header>
+  <header class="site-header">
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>
@@ -221,7 +34,7 @@
     </nav>
   </header>
 
-  <main class="page-content">
+  <main class="utility-main page-content">
     <section class="hero">
       <h1>Free Utilities</h1>
       <p>Quick tools for day-to-day developer workflows.</p>
@@ -364,7 +177,7 @@
     </section>
   </main>
 
-  <footer>
+  <footer class="site-footer">
     <h1>Hi there 👋. I am Ananth Tirumanur</h1>
     <h2>I work on projects in data science, big data, data engineering, data modeling, software engineering, and system design.</h2>
 

--- a/free-utilities/json-formatter-validator/index.html
+++ b/free-utilities/json-formatter-validator/index.html
@@ -18,7 +18,7 @@
 </head>
 <body>
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <header>
+  <header class="site-header">
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>

--- a/free-utilities/regex-tester/index.html
+++ b/free-utilities/regex-tester/index.html
@@ -20,7 +20,7 @@
 </head>
 <body>
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <header>
+  <header class="site-header">
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>

--- a/free-utilities/text-diff-checker/index.html
+++ b/free-utilities/text-diff-checker/index.html
@@ -21,7 +21,7 @@
 </head>
 <body>
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <header>
+  <header class="site-header">
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>

--- a/free-utilities/utilities-theme.css
+++ b/free-utilities/utilities-theme.css
@@ -151,3 +151,91 @@ td {
     padding: 0.9rem;
   }
 }
+
+
+.site-header {
+  background: transparent;
+  position: static;
+}
+
+.site-header nav {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.site-header nav ul li a {
+  color: var(--text-main);
+}
+
+.utility-main,
+.page-content,
+.site-footer {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.page-content {
+  padding-top: 1rem;
+  padding-bottom: 2.5rem;
+}
+
+.hero {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  padding: 1.2rem 1.3rem;
+  margin-bottom: 1.2rem;
+}
+
+.hero h1 {
+  margin: 0 0 0.35rem;
+  font-size: 1.65rem;
+}
+
+.hero p {
+  margin: 0;
+  color: var(--text-subtle);
+}
+
+.articles-section {
+  margin: 1.4rem 0 1.7rem;
+}
+
+.articles-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.85rem;
+}
+
+.article-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  box-shadow: var(--shadow);
+  transition: transform 0.15s ease;
+}
+
+.article-card:hover {
+  transform: translateY(-2px);
+}
+
+.article-card img {
+  display: block;
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+}
+
+.article-card h4 {
+  margin: 0;
+  padding: 0.75rem;
+  font-size: 0.96rem;
+  line-height: 1.35;
+}

--- a/free-utilities/uuid-ulid-generator/index.html
+++ b/free-utilities/uuid-ulid-generator/index.html
@@ -19,7 +19,7 @@
 </head>
 <body>
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNB7CZV5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <header>
+  <header class="site-header">
     <nav>
       <ul>
         <li><a href="https://www.iexpertify.com/">iExpertify</a></li>


### PR DESCRIPTION
### Motivation
- Center the `/courses/` pages on laptop/desktop viewports and make their layout consistent with other site sections. 
- Ensure the navigation/header is visible and consistent across all `courses` and `free-utilities` pages. 
- Move duplicated inline styles into a single shared stylesheet so utility pages share the same layout rules and visual patterns.

### Description
- Updated `.course-shell` in `assets/css/course-experience.css` to include `width`, `margin: 0 auto`, and horizontal `padding` so the courses pages render centered and have consistent page padding. 
- Standardized header markup by applying `class="site-header"` to header elements across course and utility pages (multiple `courses/*/index.html` and `free-utilities/*/index.html` files) to ensure consistent header behavior. 
- Extracted the free-utilities homepage inline `<style>` into `free-utilities/utilities-theme.css` and linked that stylesheet from `free-utilities/index.html` to centralize theme rules. 
- Added shared layout rules to `free-utilities/utilities-theme.css` including `.site-header` adjustments, `.site-header nav ul li a` color rule, and container classes `utility-main` / `.site-footer` / `.page-content` so spacing and header/link visibility are consistent across utilities. 

### Testing
- Served the site locally with `python3 -m http.server 4173` and verified `GET` responses for `http://127.0.0.1:4173/courses/` and `http://127.0.0.1:4173/free-utilities/` returned HTTP 200. 
- Captured visual validation screenshots using Playwright for both pages (artifacts: `courses-page.png`, `free-utilities-page.png`) to confirm layout/header appearance. 
- Confirmed header markup changes are present using a code search for `header class="site-header"` across updated pages, and verified the new CSS rules exist in `free-utilities/utilities-theme.css`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f2c8537848328b24b4be281f2972e)